### PR TITLE
Set changed_when to false for broadcasting uninstall to allow idempotency tests proceed

### DIFF
--- a/tasks/common/preflight.yml
+++ b/tasks/common/preflight.yml
@@ -5,6 +5,7 @@
     - name: Broadcast uninstall signal
       command: /bin/true
       notify: Uninstall units
+      changed_when: false
   always:
     - name: Flush handlers
       meta: flush_handlers


### PR DESCRIPTION
System unit installation fails on the idempotency test when using the role in an environment using molecule tests. This change resolves the issue.